### PR TITLE
Adding the environment variables for nodejs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,3 +17,5 @@ for file in /c7nodall/version/*;
 do
   $file
 done
+echo 'export NVM_DIR="$HOME/.nvm"' >> /etc/drydock/.env
+echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> /etc/drydock/.env


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/10664

its failing here https://rcapp.shippable.com/github/vijayreddy1991/jobs/c7nodall-testing/builds/5ad5c91efe36d80700e8ed1c/console nvm is not available in path. so adding it.

